### PR TITLE
Update keras-bert.ipynb

### DIFF
--- a/keras-bert.ipynb
+++ b/keras-bert.ipynb
@@ -357,7 +357,7 @@
     {
       "cell_type": "code",
       "source": [
-        "class BertLayer(tf.layers.Layer):\n",
+        "class BertLayer(tf.keras.layers.Layer):\n",
         "    def __init__(\n",
         "        self,\n",
         "        n_fine_tune_layers=10,\n",


### PR DESCRIPTION
TypeError will be encountered if customized bertlayer called without tf.keras.layers.